### PR TITLE
Add missing files to rockylinux-8

### DIFF
--- a/rockylinux-8/Containerfile
+++ b/rockylinux-8/Containerfile
@@ -34,6 +34,9 @@ RUN sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/s
     && systemctl enable network \
     && touch /etc/sysconfig/disable-deprecation-warnings
 
+COPY excludes /etc/warewulf/excludes
+COPY container_exit.sh /etc/warewulf/container_exit.sh
+
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \
       "\nprovisioning system.", \


### PR DESCRIPTION
The rockylinux-8 image had files for exclude and container_exit that were erroneously omitted from the container. These are now included with COPY directives.