### PR TITLE
Fix COPY directives to point to a directory

### DIFF
--- a/centos-7/Containerfile
+++ b/centos-7/Containerfile
@@ -32,8 +32,8 @@ RUN yum update -y \
     && systemctl unmask console-getty.service dev-hugepages.mount getty.target sys-fs-fuse-connections.mount systemd-logind.service systemd-remount-fs.service \
     && systemctl enable network
 
-COPY excludes /etc/warewulf/excludes
-COPY container_exit.sh /etc/warewulf/container_exit.sh
+COPY excludes /etc/warewulf/
+COPY container_exit.sh /etc/warewulf/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-8/Containerfile
+++ b/rockylinux-8/Containerfile
@@ -34,8 +34,8 @@ RUN sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/s
     && systemctl enable network \
     && touch /etc/sysconfig/disable-deprecation-warnings
 
-COPY excludes /etc/warewulf/excludes
-COPY container_exit.sh /etc/warewulf/container_exit.sh
+COPY excludes /etc/warewulf/
+COPY container_exit.sh /etc/warewulf/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \


### PR DESCRIPTION
COPY directive destinations need to be a directory. When specifying a full file path, the COPY apparently fails silently.