### PR TITLE
Add rockylinux-9 container builds pinned to the 9.0 and 9.1 releases

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -46,6 +46,14 @@ jobs:
             version: 9
             context: rockylinux-9
             file: rockylinux-9/Containerfile
+          - os: rockylinux
+            version: 9.0
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.0
+          - os: rockylinux
+            version: 9.1
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.1
           - os: leap
             version: 15
             context: leap

--- a/rockylinux-9/Containerfile
+++ b/rockylinux-9/Containerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM docker.io/library/rockylinux:9
 
 RUN dnf update -y \
     && dnf install -y --allowerasing \

--- a/rockylinux-9/Containerfile-9.0
+++ b/rockylinux-9/Containerfile-9.0
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM docker.io/library/rockylinux:9.0
 
 COPY Rocky-Vault-9.0-*.repo /etc/yum.repos.d
 

--- a/rockylinux-9/Containerfile-9.0
+++ b/rockylinux-9/Containerfile-9.0
@@ -1,0 +1,59 @@
+FROM rockylinux:9
+
+COPY Rocky-Vault-9.0-*.repo /etc/yum.repos.d
+
+RUN dnf update -y --disablerepo "*" --enablerepo *-vault-9.0 \
+    && dnf install -y --disablerepo "*" --enablerepo *-vault-9.0 --allowerasing \
+      coreutils \
+      cpio \
+      dhclient \
+      e2fsprogs \
+      ethtool \
+      findutils \
+      initscripts \
+      ipmitool \
+      iproute \
+      kernel-core \
+      kernel-modules \
+      ncurses \
+      net-tools \
+      NetworkManager \
+      nfs-utils \
+      openssh-clients \
+      openssh-server \
+      pciutils \
+      policycoreutils-python-utils \
+      psmisc \
+      rsync \
+      rsyslog \
+      strace \
+      selinux-policy-targeted \
+      wget \
+      which \
+      words \
+      rdma-core \
+    && dnf clean all
+
+RUN touch /etc/sysconfig/disable-deprecation-warnings
+
+# For SELinux enabled nodes:
+#   The wwclient service fails to start on boot if appropriate SELinux file
+#   context label is not set for /warewulf/wwclient.
+#   Permanently assign bin_t fcontent label for wwclient binary that is
+#   deployed by wwinit overlay because warewulf runs `restorecon -R /` on node
+#   boot, clobbering any existing labels set in the overlay itself.
+#
+#   WARNING: THE FOLLOWING RETURNS AN ERROR WITH libsemanage VERSIONS IN EL9
+#            PRIOR TO 3.3.3 SO WE FORCE A CLEAN EXIT CODE
+#            See: https://github.com/SELinuxProject/selinux/issues/343
+#
+RUN semanage fcontext -N -a -t bin_t /warewulf/wwclient || true
+
+COPY excludes /etc/warewulf/
+COPY container_exit.sh /etc/warewulf/
+
+CMD [ "/bin/echo", "-e", \
+      "This image is intended to be used with the Warewulf cluster management and", \
+      "\nprovisioning system.", \
+      "\n", \
+      "\nFor more information about Warewulf, visit https://warewulf.org" ]

--- a/rockylinux-9/Containerfile-9.1
+++ b/rockylinux-9/Containerfile-9.1
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM docker.io/library/rockylinux:9.1
 
 COPY Rocky-Static-9.1-*.repo /etc/yum.repos.d
 

--- a/rockylinux-9/Containerfile-9.1
+++ b/rockylinux-9/Containerfile-9.1
@@ -1,0 +1,55 @@
+FROM rockylinux:9
+
+COPY Rocky-Static-9.1-*.repo /etc/yum.repos.d
+
+RUN dnf update -y --disablerepo "*" --enablerepo *-static-9.1 \
+    && dnf install -y --disablerepo "*" --enablerepo *-static-9.1 --allowerasing \
+      coreutils \
+      cpio \
+      dhclient \
+      e2fsprogs \
+      ethtool \
+      findutils \
+      initscripts \
+      ipmitool \
+      iproute \
+      kernel-core \
+      kernel-modules \
+      ncurses \
+      net-tools \
+      NetworkManager \
+      nfs-utils \
+      openssh-clients \
+      openssh-server \
+      pciutils \
+      policycoreutils-python-utils \
+      psmisc \
+      rsync \
+      rsyslog \
+      strace \
+      selinux-policy-targeted \
+      wget \
+      which \
+      words \
+      rdma-core \
+    && dnf clean all
+
+RUN touch /etc/sysconfig/disable-deprecation-warnings
+
+# For SELinux enabled nodes:
+#   The wwclient service fails to start on boot if appropriate SELinux file
+#   context label is not set for /warewulf/wwclient.
+#   Permanently assign bin_t fcontent label for wwclient binary that is
+#   deployed by wwinit overlay because warewulf runs `restorecon -R /` on node
+#   boot, clobbering any existing labels set in the overlay itself.
+#
+RUN semanage fcontext -N -a -t bin_t /warewulf/wwclient
+
+COPY excludes /etc/warewulf/
+COPY container_exit.sh /etc/warewulf/
+
+CMD [ "/bin/echo", "-e", \
+      "This image is intended to be used with the Warewulf cluster management and", \
+      "\nprovisioning system.", \
+      "\n", \
+      "\nFor more information about Warewulf, visit https://warewulf.org" ]

--- a/rockylinux-9/Rocky-Static-9.1-AppStream.repo
+++ b/rockylinux-9/Rocky-Static-9.1-AppStream.repo
@@ -1,0 +1,7 @@
+[appstream-static-9.1]
+name=Rocky Linux 9.1 - AppStream
+baseurl=http://dl.rockylinux.org/pub/rocky/9.1/AppStream/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Static-9.1-AppStream.repo
+++ b/rockylinux-9/Rocky-Static-9.1-AppStream.repo
@@ -1,6 +1,6 @@
 [appstream-static-9.1]
 name=Rocky Linux 9.1 - AppStream
-baseurl=http://dl.rockylinux.org/pub/rocky/9.1/AppStream/$basearch/os/
+baseurl=http://dl.rockylinux.org/vault/rocky/9.1/AppStream/$basearch/os/
 gpgcheck=1
 enabled=0
 countme=1

--- a/rockylinux-9/Rocky-Static-9.1-BaseOS.repo
+++ b/rockylinux-9/Rocky-Static-9.1-BaseOS.repo
@@ -1,0 +1,7 @@
+[baseos-static-9.1]
+name=Rocky Linux 9.1 - BaseOS
+baseurl=http://dl.rockylinux.org/pub/rocky/9.1/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Static-9.1-BaseOS.repo
+++ b/rockylinux-9/Rocky-Static-9.1-BaseOS.repo
@@ -1,6 +1,6 @@
 [baseos-static-9.1]
 name=Rocky Linux 9.1 - BaseOS
-baseurl=http://dl.rockylinux.org/pub/rocky/9.1/BaseOS/$basearch/os/
+baseurl=http://dl.rockylinux.org/vault/rocky/9.1/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=0
 countme=1

--- a/rockylinux-9/Rocky-Static-9.1-CBR.repo
+++ b/rockylinux-9/Rocky-Static-9.1-CBR.repo
@@ -1,0 +1,7 @@
+[baseos-static-9.1]
+name=Rocky Linux 9.1 - BaseOS
+baseurl=http://dl.rockylinux.org/pub/rocky/9.1/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Static-9.1-CBR.repo
+++ b/rockylinux-9/Rocky-Static-9.1-CBR.repo
@@ -1,6 +1,6 @@
 [baseos-static-9.1]
 name=Rocky Linux 9.1 - BaseOS
-baseurl=http://dl.rockylinux.org/pub/rocky/9.1/BaseOS/$basearch/os/
+baseurl=http://dl.rockylinux.org/vault/rocky/9.1/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=0
 countme=1

--- a/rockylinux-9/Rocky-Static-9.1-Extras.repo
+++ b/rockylinux-9/Rocky-Static-9.1-Extras.repo
@@ -1,6 +1,6 @@
 [extras-static-9.1]
 name=Rocky Linux 9.1 - Extras
-baseurl=http://dl.rockylinux.org/pub/rocky/9.1/extras/$basearch/os/
+baseurl=http://dl.rockylinux.org/vault/rocky/9.1/extras/$basearch/os/
 gpgcheck=1
 enabled=0
 countme=1

--- a/rockylinux-9/Rocky-Static-9.1-Extras.repo
+++ b/rockylinux-9/Rocky-Static-9.1-Extras.repo
@@ -1,0 +1,7 @@
+[extras-static-9.1]
+name=Rocky Linux 9.1 - Extras
+baseurl=http://dl.rockylinux.org/pub/rocky/9.1/extras/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Vault-9.0-AppStream.repo
+++ b/rockylinux-9/Rocky-Vault-9.0-AppStream.repo
@@ -1,0 +1,7 @@
+[appstream-vault-9.0]
+name=Rocky Linux 9.0 - AppStream
+baseurl=http://dl.rockylinux.org/vault/rocky/9.0/AppStream/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Vault-9.0-BaseOS.repo
+++ b/rockylinux-9/Rocky-Vault-9.0-BaseOS.repo
@@ -1,0 +1,7 @@
+[baseos-vault-9.0]
+name=Rocky Linux 9.0 - BaseOS
+baseurl=http://dl.rockylinux.org/vault/rocky/9.0/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Vault-9.0-CBR.repo
+++ b/rockylinux-9/Rocky-Vault-9.0-CBR.repo
@@ -1,0 +1,7 @@
+[crb-vault-9.0]
+name=Rocky Linux 9.0 - CRB
+baseurl=http://dl.rockylinux.org/vault/rocky/9.0/CRB/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9

--- a/rockylinux-9/Rocky-Vault-9.0-Extras.repo
+++ b/rockylinux-9/Rocky-Vault-9.0-Extras.repo
@@ -1,0 +1,7 @@
+[extras-vault-9.0]
+name=Rocky Linux 9.0 - Extras
+baseurl=http://dl.rockylinux.org/vault/rocky/9.0/extras/$basearch/os/
+gpgcheck=1
+enabled=0
+countme=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9


### PR DESCRIPTION
This PR adds rockylinux-9 container builds for warewulf pinned to the Rocky Linux 9.0 and Rocky Linux 9.1 releases.

I stumbled into an obscure bug with libsemanage-3.3.2 in 9.0 that resulted in the `semanage fcontext` command returning an error during the container build. To handle that, I've forced a clean exit by appending `|| true`  to the `RUN semanage fcontext ...` command in `Containerfile-9.0`, adding a comment and a link to the issue.

