### PR TITLE
Stop configuring broken_shadow

### DIFF
--- a/rockylinux-8/Containerfile
+++ b/rockylinux-8/Containerfile
@@ -28,9 +28,7 @@ RUN dnf update -y \
       words \
     && dnf clean all
 
-RUN sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/system-auth \
-    && sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/password-auth \
-    && rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
+RUN rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
     && systemctl unmask console-getty.service dev-hugepages.mount getty.target sys-fs-fuse-connections.mount systemd-logind.service systemd-remount-fs.service \
     && systemctl enable network \
     && touch /etc/sysconfig/disable-deprecation-warnings

--- a/rockylinux-8/Containerfile-8.6
+++ b/rockylinux-8/Containerfile-8.6
@@ -30,9 +30,7 @@ RUN dnf update -y --disablerepo "*" --enablerepo *-vault-8.6 \
          words \
     && dnf clean all
 
-RUN sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/system-auth \
-    && sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/password-auth \
-    && rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
+RUN rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
     && systemctl unmask console-getty.service dev-hugepages.mount getty.target sys-fs-fuse-connections.mount systemd-logind.service systemd-remount-fs.service \
     && systemctl enable network \
     && touch /etc/sysconfig/disable-deprecation-warnings

--- a/rockylinux-8/Containerfile-8.7
+++ b/rockylinux-8/Containerfile-8.7
@@ -30,9 +30,7 @@ RUN dnf update -y --disablerepo "*" --enablerepo *-static-8.7 \
          words \
     && dnf clean all
 
-RUN sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/system-auth \
-    && sed -i -e '/^account.*pam_unix\.so\s*$/s/\s*$/\ broken_shadow/' /etc/pam.d/password-auth \
-    && rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
+RUN rm -f /etc/sysconfig/network-scripts/ifcfg-e* \
     && systemctl unmask console-getty.service dev-hugepages.mount getty.target sys-fs-fuse-connections.mount systemd-logind.service systemd-remount-fs.service \
     && systemctl enable network \
     && touch /etc/sysconfig/disable-deprecation-warnings


### PR DESCRIPTION
broken_shadow has historically been added to Rocky Linux node images; but this is generally defined at https://github.com/hpcng/warewulf/blob/development/overlays/wwinit/warewulf/init.d/75-vnfs_fixes already/now, so it shouldn't need to be in the image explicitly.