### PR TITLE
Remove all original yum repos from pinned rockylinux images

### DIFF
--- a/rockylinux-8/Containerfile-8.6
+++ b/rockylinux-8/Containerfile-8.6
@@ -1,8 +1,9 @@
 FROM docker.io/library/rockylinux:8.6
 
-COPY yum.repos.d-8.6/*.repo /etc/yum.repos.d
+RUN rm -f /etc/yum.repos.d/*.repo \
+    && dnf clean all
 
-RUN dnf clean all
+COPY yum.repos.d-8.6/*.repo /etc/yum.repos.d
 
 RUN dnf update -y \
     && dnf install -y --allowerasing \

--- a/rockylinux-8/Containerfile-8.7
+++ b/rockylinux-8/Containerfile-8.7
@@ -1,8 +1,9 @@
 FROM docker.io/library/rockylinux:8.7
 
-COPY yum.repos.d-8.7/*.repo /etc/yum.repos.d
+RUN rm -f /etc/yum.repos.d/*.repo \
+    && dnf clean all
 
-RUN dnf clean all
+COPY yum.repos.d-8.7/*.repo /etc/yum.repos.d
 
 RUN dnf update -y \
     && dnf install -y --allowerasing \

--- a/rockylinux-8/Containerfile-8.8
+++ b/rockylinux-8/Containerfile-8.8
@@ -1,8 +1,9 @@
 FROM docker.io/library/rockylinux:8.8
 
-COPY yum.repos.d-8.8/*.repo /etc/yum.repos.d
+RUN rm -f /etc/yum.repos.d/*.repo \
+    && dnf clean all
 
-RUN dnf clean all
+COPY yum.repos.d-8.8/*.repo /etc/yum.repos.d
 
 RUN dnf update -y \
     && dnf install -y --allowerasing \

--- a/rockylinux-9/Containerfile-9.0
+++ b/rockylinux-9/Containerfile-9.0
@@ -1,8 +1,9 @@
 FROM docker.io/library/rockylinux:9.0
 
-COPY yum.repos.d-9.0/*.repo /etc/yum.repos.d
+RUN rm -f /etc/yum.repos.d/*.repo \
+    && dnf clean all
 
-RUN dnf clean all
+COPY yum.repos.d-9.0/*.repo /etc/yum.repos.d
 
 RUN dnf update -y \
     && dnf install -y --allowerasing \

--- a/rockylinux-9/Containerfile-9.1
+++ b/rockylinux-9/Containerfile-9.1
@@ -1,5 +1,8 @@
 FROM docker.io/library/rockylinux:9.1
 
+RUN rm -f /etc/yum.repos.d/*.repo \
+    && dnf clean all
+
 COPY yum.repos.d-9.1/*.repo /etc/yum.repos.d
 
 RUN dnf update -y \


### PR DESCRIPTION
Rather than depend on incomming repos successfully replacing existing repos, completely remove original repos first.